### PR TITLE
use googlemap api to replace mapbox api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -607,25 +607,24 @@ for triInfo     <-                             triWorld,    normalWorld
             case 'mapbox-terrain-vector':
                 prefix = 'https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2';
                 res = '.vector.pbf';
-                break;
+                return `${prefix}/${zoompos.join('/')}${res}?access_token=${token}`;
             case 'mapbox-terrain-rgb':
                 prefix = `https://api.mapbox.com/v4/mapbox.terrain-rgb`;
                 res = '@2x.pngraw';
-                break;
+                return `${prefix}/${zoompos.join('/')}${res}?access_token=${token}`;
             case 'mapbox-satellite':
-                prefix = `https://api.mapbox.com/v4/mapbox.streets-satellite`;
+                prefix = `https://khms0.google.com/kh/v=860`;
                 // https://www.mapbox.com/api-documentation/#retrieve-tiles
                 // mapbox-satellite-14-3072-6420.blob
                 // res = '@2x.png'; // 176813 (will get a jpg by spec)
                 // res = '@2x.jpg90'; // 132759
                 // res = '@2x.jpg80';
                 res = '@2x.jpg70'; // 72828
-                break;
+                return `${prefix}?x=${zoompos[1]}&y=${zoompos[2]}&z=${zoompos[0]}`;
             default:
                 console.log('unsupported api:', api);
                 return '';
         }
-        return `${prefix}/${zoompos.join('/')}${res}?access_token=${token}`;
     }
 
     static isAjaxSuccessful(stat) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,7 @@ if (env === 'build') {
 const config = {
     entry: __dirname + '/src/index.js',
     externals: { // https://webpack.js.org/configuration/externals/
-        three: 'THREE'
+        three: 'three'
     },
     output: {
         path: __dirname + '/lib',


### PR DESCRIPTION
1. I found that when using mapbox api to fetch tiles images,some images are ugly, with a clear dividing line with different pictures, like this:
![image](https://user-images.githubusercontent.com/14245159/69780419-2dfe1d00-11e6-11ea-8468-1592090efaaa.png)

so I use googlemap tiles imagery to replace mapbox tiles imagery ,
```js
switch (api) {
            case 'mapbox-terrain-vector':
                prefix = 'https://api.mapbox.com/v4/mapbox.mapbox-terrain-v2';
                res = '.vector.pbf';
                return `${prefix}/${zoompos.join('/')}${res}?access_token=${token}`;
            case 'mapbox-terrain-rgb':
                prefix = `https://api.mapbox.com/v4/mapbox.terrain-rgb`;
                res = '@2x.pngraw';
                return `${prefix}/${zoompos.join('/')}${res}?access_token=${token}`;
            case 'mapbox-satellite':
                prefix = `https://khms0.google.com/kh/v=860`;
                // https://www.mapbox.com/api-documentation/#retrieve-tiles
                // mapbox-satellite-14-3072-6420.blob
                // res = '@2x.png'; // 176813 (will get a jpg by spec)
                // res = '@2x.jpg90'; // 132759
                // res = '@2x.jpg80';
                res = '@2x.jpg70'; // 72828
                return `${prefix}?x=${zoompos[1]}&y=${zoompos[2]}&z=${zoompos[0]}`;
            default:
                console.log('unsupported api:', api);
                return '';
        }
```
it is better now,like this:
![image](https://user-images.githubusercontent.com/14245159/69780574-9ea53980-11e6-11ea-8694-ed5973212c81.png)
 2. When I use three-geo from npm. Follow the [instructions](https://www.npmjs.com/package/three-geo),I import threeGeo from 'three-geo/src',and I must cd module and excute npm install, and throw some errors,it is because I use different three version in one project.So I import threeGeo from 'three-geo/dist/three-geo',it throw errors onece agian,remind me can not find module 'THREE'.So I replace three externals with three on webpack.config.js .

```js
externals: { // https://webpack.js.org/configuration/externals/
        three: 'three'
    },
```
